### PR TITLE
update node 12 box to devtoolset 9

### DIFF
--- a/12/amd64.dockerfile
+++ b/12/amd64.dockerfile
@@ -9,8 +9,11 @@ ENV NODE_PATH=/opt/node-v$NODE_VERSION-linux-x64/lib/node_modules
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
   && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
   && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-RUN yum -y install centos-release-scl \
-  && yum -y install devtoolset-9 \
+RUN yum -y install centos-release-scl
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN yum -y install devtoolset-9 \
   && yum groupinstall -y 'Development Tools' \
   && yum install -y curl-devel expat-devel gettext-devel openssl-devel perl-CPAN perl-devel wget zlib-devel \
   && yum clean all
@@ -26,8 +29,8 @@ RUN curl -fksSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz
-RUN ln -s --force /opt/rh/devtoolset-8/root/bin/gcc /usr/bin/gcc
-RUN ln -s --force /opt/rh/devtoolset-8/root/bin/g++ /usr/bin/g++
+RUN ln -s --force /opt/rh/devtoolset-9/root/bin/gcc /usr/bin/gcc
+RUN ln -s --force /opt/rh/devtoolset-9/root/bin/g++ /usr/bin/g++
 RUN wget https://github.com/git/git/archive/v$GIT_VERSION.tar.gz
 RUN tar xvf v$GIT_VERSION.tar.gz
 

--- a/12/amd64.dockerfile
+++ b/12/amd64.dockerfile
@@ -1,13 +1,16 @@
 FROM centos:centos7
 
-ENV NODE_VERSION 12.0.0
-ENV YARN_VERSION 1.19.1
-ENV GIT_VERSION 2.18.0
+ENV NODE_VERSION=12.0.0
+ENV YARN_VERSION=1.19.1
+ENV GIT_VERSION=2.18.0
 
-ENV NODE_PATH /opt/node-v$NODE_VERSION-linux-x64/lib/node_modules
+ENV NODE_PATH=/opt/node-v$NODE_VERSION-linux-x64/lib/node_modules
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 RUN yum -y install centos-release-scl \
-  && yum -y install devtoolset-8-* \
+  && yum -y install devtoolset-9 \
   && yum groupinstall -y 'Development Tools' \
   && yum install -y curl-devel expat-devel gettext-devel openssl-devel perl-CPAN perl-devel wget zlib-devel \
   && yum clean all

--- a/12/arm32v7.dockerfile
+++ b/12/arm32v7.dockerfile
@@ -1,6 +1,6 @@
 FROM alpine AS builder
 
-ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
+ENV QEMU_URL=https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
 RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 
 # TODO: make this work with centos7 instead
@@ -10,10 +10,10 @@ COPY --from=builder qemu-arm-static /usr/bin
 
 SHELL ["/bin/bash", "--login", "-c"]
 
-ENV NODE_VERSION 12.0.0
-ENV YARN_VERSION 1.19.1
+ENV NODE_VERSION=12.0.0
+ENV YARN_VERSION=1.19.1
 
-ENV NODE_PATH /opt/node-v$NODE_VERSION-linux-armv7l/lib/node_modules
+ENV NODE_PATH=/opt/node-v$NODE_VERSION-linux-armv7l/lib/node_modules
 
 RUN apt-get update \
   && apt-get -y install build-essential software-properties-common \

--- a/12/arm32v7.dockerfile
+++ b/12/arm32v7.dockerfile
@@ -34,5 +34,5 @@ RUN curl -fksSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz
-RUN ln -s --force /usr/bin/gcc-8 /usr/bin/gcc
-RUN ln -s --force /usr/bin/g++-8 /usr/bin/g++
+RUN ln -s --force /usr/bin/gcc-9 /usr/bin/gcc
+RUN ln -s --force /usr/bin/g++-9 /usr/bin/g++

--- a/12/arm32v7.dockerfile
+++ b/12/arm32v7.dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
   && add-apt-repository -y ppa:git-core/ppa \
   && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
   && apt-get update \
-  && apt-get -y install curl gcc-8 git g++-8 make python-dev \
+  && apt-get -y install curl gcc-9 git g++-9 make python-dev \
   && apt-get clean
 RUN mkdir -p /opt
 RUN curl -fksSLO --compressed "https://nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-armv7l.tar.gz" \

--- a/12/arm64v8.dockerfile
+++ b/12/arm64v8.dockerfile
@@ -16,8 +16,11 @@ ENV NODE_PATH /opt/node-v$NODE_VERSION-linux-arm64/lib/node_modules
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
   && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
   && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-RUN yum -y install centos-release-scl \
-  && yum -y install devtoolset-9 \
+RUN yum -y install centos-release-scl
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN yum -y install devtoolset-9 \
   && yum groupinstall -y 'Development Tools' \
   && yum install -y curl-devel expat-devel gettext-devel openssl-devel perl-CPAN perl-devel wget zlib-devel \
   && yum clean all
@@ -33,8 +36,8 @@ RUN curl -fksSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz
-RUN ln -s --force /opt/rh/devtoolset-8/root/bin/gcc /usr/bin/gcc
-RUN ln -s --force /opt/rh/devtoolset-8/root/bin/g++ /usr/bin/g++
+RUN ln -s --force /opt/rh/devtoolset-9/root/bin/gcc /usr/bin/gcc
+RUN ln -s --force /opt/rh/devtoolset-9/root/bin/g++ /usr/bin/g++
 RUN wget https://github.com/git/git/archive/v$GIT_VERSION.tar.gz
 RUN tar xvf v$GIT_VERSION.tar.gz
 

--- a/12/arm64v8.dockerfile
+++ b/12/arm64v8.dockerfile
@@ -1,6 +1,6 @@
 FROM alpine AS builder
 
-ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz
+ENV QEMU_URL=https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz
 RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 
 FROM arm64v8/centos:centos7

--- a/12/arm64v8.dockerfile
+++ b/12/arm64v8.dockerfile
@@ -7,11 +7,11 @@ FROM arm64v8/centos:centos7
 
 COPY --from=builder qemu-aarch64-static /usr/bin
 
-ENV NODE_VERSION 12.0.0
-ENV YARN_VERSION 1.19.1
-ENV GIT_VERSION 2.18.0
+ENV NODE_VERSION=12.0.0
+ENV YARN_VERSION=1.19.1
+ENV GIT_VERSION=2.18.0
 
-ENV NODE_PATH /opt/node-v$NODE_VERSION-linux-arm64/lib/node_modules
+ENV NODE_PATH=/opt/node-v$NODE_VERSION-linux-arm64/lib/node_modules
 
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
   && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \

--- a/12/arm64v8.dockerfile
+++ b/12/arm64v8.dockerfile
@@ -13,11 +13,14 @@ ENV GIT_VERSION=2.18.0
 
 ENV NODE_PATH=/opt/node-v$NODE_VERSION-linux-arm64/lib/node_modules
 
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+RUN sed -i 's/mirror.centos.org\/altarch/mirror.chpc.utah.edu\/pub\/centos\-altarch/g' /etc/yum.repos.d/*.repo \
+  && sed -i 's/mirror.centos.org\/centos/mirror.chpc.utah.edu\/pub\/centos\-altarch/g' /etc/yum.repos.d/*.repo \
   && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
   && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN cat /etc/yum.repos.d/CentOS-Base.repo
 RUN yum -y install centos-release-scl
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+RUN sed -i 's/mirror.centos.org\/altarch/mirror.chpc.utah.edu\/pub\/centos\-altarch/g' /etc/yum.repos.d/*.repo \
+  && sed -i 's/mirror.centos.org\/centos/mirror.chpc.utah.edu\/pub\/centos\-altarch/g' /etc/yum.repos.d/*.repo \
   && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
   && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 RUN yum -y install devtoolset-9 \

--- a/12/arm64v8.dockerfile
+++ b/12/arm64v8.dockerfile
@@ -13,8 +13,11 @@ ENV GIT_VERSION 2.18.0
 
 ENV NODE_PATH /opt/node-v$NODE_VERSION-linux-arm64/lib/node_modules
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
+  && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 RUN yum -y install centos-release-scl \
-  && yum -y install devtoolset-8-* \
+  && yum -y install devtoolset-9 \
   && yum groupinstall -y 'Development Tools' \
   && yum install -y curl-devel expat-devel gettext-devel openssl-devel perl-CPAN perl-devel wget zlib-devel \
   && yum clean all

--- a/12/arm64v8.dockerfile
+++ b/12/arm64v8.dockerfile
@@ -17,7 +17,6 @@ RUN sed -i 's/mirror.centos.org\/altarch/mirror.chpc.utah.edu\/pub\/centos\-alta
   && sed -i 's/mirror.centos.org\/centos/mirror.chpc.utah.edu\/pub\/centos\-altarch/g' /etc/yum.repos.d/*.repo \
   && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo \
   && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-RUN cat /etc/yum.repos.d/CentOS-Base.repo
 RUN yum -y install centos-release-scl
 RUN sed -i 's/mirror.centos.org\/altarch/mirror.chpc.utah.edu\/pub\/centos\-altarch/g' /etc/yum.repos.d/*.repo \
   && sed -i 's/mirror.centos.org\/centos/mirror.chpc.utah.edu\/pub\/centos\-altarch/g' /etc/yum.repos.d/*.repo \

--- a/12/i386.dockerfile
+++ b/12/i386.dockerfile
@@ -26,5 +26,5 @@ RUN curl -fksSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz
-RUN ln -s --force /usr/bin/gcc-8 /usr/bin/gcc
-RUN ln -s --force /usr/bin/g++-8 /usr/bin/g++
+RUN ln -s --force /usr/bin/gcc-9 /usr/bin/gcc
+RUN ln -s --force /usr/bin/g++-9 /usr/bin/g++

--- a/12/i386.dockerfile
+++ b/12/i386.dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
   && add-apt-repository -y ppa:git-core/ppa \
   && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
   && apt-get update \
-  && apt-get -y install curl gcc-8 git g++-8 make python-dev \
+  && apt-get -y install curl gcc-9 git g++-9 make python-dev \
   && apt-get clean
 RUN mkdir -p /opt
 RUN curl -fksSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x86.tar.gz" \

--- a/12/i386.dockerfile
+++ b/12/i386.dockerfile
@@ -2,10 +2,10 @@ FROM i386/ubuntu:14.04
 
 SHELL ["/bin/bash", "--login", "-c"]
 
-ENV NODE_VERSION 12.0.0
-ENV YARN_VERSION 1.19.1
+ENV NODE_VERSION=12.0.0
+ENV YARN_VERSION=1.19.1
 
-ENV NODE_PATH /opt/node-v$NODE_VERSION-linux-x86/lib/node_modules
+ENV NODE_PATH=/opt/node-v$NODE_VERSION-linux-x86/lib/node_modules
 
 RUN apt-get update \
   && apt-get -y install build-essential software-properties-common \


### PR DESCRIPTION
Update Node 12 box to devtoolset 9. I tried updating to 11 but it doesn't seem to exist for Ubuntu 14.04. I then tried to switch the arm32 image to CentOS 7 but it doesn't have any functional repo for arm32.